### PR TITLE
Simplifica template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,9 @@
-## 📝 Descrição do PR
-> Resuma o que foi feito neste PR. Qual problema ele resolve?
-Este PR resolve a Issue # (coloque o número da Issue aqui).
+## Descrição do PR
 
-## ✅ Checklist do Desenvolvedor
-> Marque todos os itens antes de solicitar revisão.
+<!-- Explique o que mudou, por que foi necessário, como validar e eventuais riscos. -->
 
-- [ ] Meu código segue o padrão `.editorconfig` do projeto.
-- [ ] Eu mesmo revisei meu código antes de abrir este PR.
-- [ ] O código compila sem erros ou novos *warnings*.
-- [ ] Eu adicionei ou atualizei os testes unitários para cobrir essa nova lógica.
-- [ ] Testei a funcionalidade localmente e ela atende a **todos** os Critérios de Aceite do PO.
-- [ ] Aguardei outro dev ou CodeRabbit (IA) analisar o PR e já resolvi os apontamentos dele.
+<!--
+Depois de abrir o PR, publique este comentário:
 
-## 📸 Evidências (Opcional)
-> Print da tela ou do Postman/Swagger funcionando.
+@codex review em busca de regressões de segurança, testes ausentes e mudanças de comportamento arriscadas. Publique todos os comentários da revisão em português do Brasil.
+-->


### PR DESCRIPTION
## Resumo

- mantém somente a seção de descrição do PR;
- remove o checklist genérico;
- adiciona uma orientação invisível para solicitar o review manual do Codex;
- pede que os comentários da revisão sejam publicados em português do Brasil.

## Validação

- `git diff --check`.